### PR TITLE
fix: align environment variable naming convention between env.sh and …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,11 @@ k8s/*-secret.yml
 secrets.yaml
 infra/k8s/config/secrets.yaml
 
+# Logs
+*-port-forward.log
+frontend-port-forward.log
+backend-port-forward.log
+
 # Misc
 .DS_Store
 .idea/

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -29,6 +29,9 @@ RUN rm -rf /etc/nginx/conf.d/*
 COPY --from=builder /app/dist/ /usr/share/nginx/html/
 
 
+# Create a runtime environment config
+RUN echo "window.ENV = {};" > /usr/share/nginx/html/env-config.js
+
 # Copy nginx 
 COPY nginx.conf /etc/nginx/templates/nginx.conf
 

--- a/apps/frontend/env.sh
+++ b/apps/frontend/env.sh
@@ -7,4 +7,18 @@ export BACKEND_SERVICE_PORT=${BACKEND_SERVICE_PORT:-8000}
 echo "Injecting environment variables into nginx.conf..."
 envsubst '${BACKEND_SERVICE_HOST} ${BACKEND_SERVICE_PORT}' < /etc/nginx/templates/nginx.conf > /etc/nginx/conf.d/default.conf
 
-echo "NGINX config ready with backend host: ${BACKEND_SERVICE_HOST}:${BACKEND_SERVICE_PORT}"
+# Create JavaScript environment config
+cat > /usr/share/nginx/html/env-config.js << EOF
+window.ENV = {
+  VITE_API_BASE_URL: "${VITE_API_BASE_URL}",
+  VITE_API_URL: "${VITE_API_URL}",
+  VITE_MEDIA_URL: "${VITE_MEDIA_URL}",
+  VITE_STATIC_URL: "${VITE_STATIC_URL}",
+  VITE_WEATHER_API_KEY: "${VITE_WEATHER_API_KEY}",
+  VITE_PAYPAL_CLIENT_ID: "${VITE_PAYPAL_CLIENT_ID}",
+  VITE_GOOGLE_MAPS_API_KEY: "${VITE_GOOGLE_MAPS_API_KEY}",
+  VITE_GOOGLE_CLOUD_VISION_API_KEY: "${VITE_GOOGLE_CLOUD_VISION_API_KEY}"
+};
+EOF
+
+echo "Environment configuration ready"

--- a/apps/frontend/src/components/Dashboard/PlantIdentifier.jsx
+++ b/apps/frontend/src/components/Dashboard/PlantIdentifier.jsx
@@ -85,7 +85,7 @@ const PlantIdentifier = () => {
     };
 
     try {
-      const apiKey = window._env_?.VITE_GOOGLE_CLOUD_VISION_API_KEY || import.meta.env.VITE_GOOGLE_CLOUD_VISION_API_KEY;
+      const apiKey = window.ENV?.VITE_GOOGLE_CLOUD_VISION_API_KEY || import.meta.env.VITE_GOOGLE_CLOUD_VISION_API_KEY;
       if (!apiKey) {
         throw new Error('API key is not configured');
       }

--- a/apps/frontend/src/components/Dashboard/Weather.jsx
+++ b/apps/frontend/src/components/Dashboard/Weather.jsx
@@ -165,7 +165,7 @@ const ErrorMessage = ({ message }) => (
 );
 
 function Weather() {
-  const API_KEY = window._env_?.VITE_WEATHER_API_KEY || import.meta.env.VITE_WEATHER_API_KEY;
+  const API_KEY = window.ENV?.VITE_WEATHER_API_KEY || import.meta.env.VITE_WEATHER_API_KEY;
   
   console.log('Weather API Key:', API_KEY); // Debug line
   

--- a/apps/frontend/src/hooks/useMapLogic.js
+++ b/apps/frontend/src/hooks/useMapLogic.js
@@ -4,7 +4,7 @@ const LIBRARIES = ['places'];
 
 const useMapLogic = () => {
   // Get API key from runtime environment variables
-  const apiKey = window._env_?.VITE_GOOGLE_MAPS_API_KEY || process.env.VITE_GOOGLE_MAPS_API_KEY;
+  const apiKey = window.ENV?.VITE_GOOGLE_MAPS_API_KEY || process.env.VITE_GOOGLE_MAPS_API_KEY;
   
   const { isLoaded, loadError } = useLoadScript({
     googleMapsApiKey: apiKey,

--- a/apps/frontend/src/pages/OrderPage.jsx
+++ b/apps/frontend/src/pages/OrderPage.jsx
@@ -32,7 +32,7 @@ function OrderPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const orderId = id;
-  const PAYPAL_CLIENT_ID = window._env_?.VITE_PAYPAL_CLIENT_ID || import.meta.env.VITE_PAYPAL_CLIENT_ID || '';
+  const PAYPAL_CLIENT_ID = window.ENV?.VITE_PAYPAL_CLIENT_ID || import.meta.env.VITE_PAYPAL_CLIENT_ID || '';
   const dispatch = useDispatch();
 
   const orderDetails = useSelector(state => state.orderDetails);
@@ -56,7 +56,7 @@ function OrderPage() {
 
   const getImageUrl = imagePath => {
     // Use window._env_ first, then fall back to import.meta.env
-    const baseUrl = window._env_?.VITE_API_BASE_URL || import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+    const baseUrl = window.ENV?.VITE_API_BASE_URL || import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
     
     if (!imagePath) {
       return `${baseUrl}/media/default/placeholder.jpg`;

--- a/docs/minikube_deployment_guide.md
+++ b/docs/minikube_deployment_guide.md
@@ -65,18 +65,45 @@ brew install minikube
 
 ## 🚀 Deployment Process
 
+### Note that you will first have to crate a secrets.yaml file 
+## 📄 Secrets File Location
+```bash
+infra/k8s/eks/secrets.yaml
+```
+
+###  Example Structure
+```bash
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bonsai-secrets
+  namespace: bonsai
+type: Opaque
+stringData:
+  DB_PASSWORD: "<your-db-password>"
+  SECRET_KEY: "<your-django-secret-key>"
+  DJANGO_SUPERUSER_USERNAME: "<your-admin-username>"
+  DJANGO_SUPERUSER_EMAIL: "<your-admin-email>"
+  DJANGO_SUPERUSER_PASSWORD: "<your-admin-password>"
+
+
+  VITE_WEATHER_API_KEY: "<your-weather-api-key>"
+  VITE_PAYPAL_CLIENT_ID: "<your-paypal-client-id>"
+  VITE_GOOGLE_MAPS_API_KEY: "<your-google-maps-api-key>"
+  VITE_GOOGLE_CLOUD_VISION_API_KEY: "<your-google-vision-api-key>"
+```
 ### 1. Using the Deployment Script
 
 The project includes an automated deployment script
 (`infra/k8s/minikube-deploy.sh`) that handles the entire deployment process. To
 use it:
 
+
 ```bash
 # Make the script executable
-chmod +x infra/k8s/minikube-deploy.sh
-
-# Run the deployment script
-./infra/k8s/minikube-deploy.sh
+chmod +x infra/k8s/minikube-deploy.sh 
+# Run the deployment script and set up port forwarding automatically
+./infra/k8s/minikube-deploy.sh --background
 ```
 
 The script will:
@@ -87,6 +114,7 @@ The script will:
 - Create Kubernetes namespace
 - Set up ConfigMaps and Secrets
 - Deploy services and applications
+- Enable port forwarding for frontend and backend access
 
 ### 2. Manual Deployment Steps
 
@@ -215,7 +243,20 @@ kubectl get ingress -n bonsai
 
 There are several ways to access your application in Minikube:
 
-1. **Using the Ingress (Recommended)**
+
+1. **Using Port Forwarding**
+
+   ```bash
+   # Forward frontend service
+   kubectl port-forward service/bonsai-frontend 8090:80 -n bonsai
+   # Access at: http://localhost:8090
+
+   # Forward backend service
+   kubectl port-forward service/bonsai-backend 8000:8000 -n bonsai
+   # Access at: http://localhost:8000
+   ```
+
+2. **Using the Ingress 
 
    ```bash
    # First, ensure ingress is enabled
@@ -231,18 +272,6 @@ There are several ways to access your application in Minikube:
    # Now you can access the application at:
    # Frontend: http://bonsai.local
    # Backend API: http://bonsai.local/api
-   ```
-
-2. **Using Port Forwarding**
-
-   ```bash
-   # Forward frontend service
-   kubectl port-forward service/bonsai-frontend 8090:80 -n bonsai
-   # Access at: http://localhost:8090
-
-   # Forward backend service
-   kubectl port-forward service/bonsai-backend 8000:8000 -n bonsai
-   # Access at: http://localhost:8000
    ```
 
 3. **Using Minikube Service**
@@ -332,6 +361,14 @@ Kubernetes, especially with port forwarding. Here's how to resolve them:
 
 | Command                                    | Description                  |
 | ------------------------------------------ | ---------------------------- |
+| `kubectl get pods`                         | Get pods in current namespace|
+| `kubectl get pods -o wide`                 | Get detailed pod information |
+| `kubectl describe pod <pod-name>`          | Describe pod                 |
+| `kubectl get nodes`                        | List cluster nodes           |
+| `kubectl describe node <node-name>`        | Describe node                |
+| `kubectl get services`                     | Get services                 |
+| `kubectl get pv`                           | Get Persistent volumes       |
+| `kubectl get pvc`                          | Get Persistent volume claims |
 | `kubectl logs <pod-name>`                  | View pod logs                |
 | `kubectl describe pod <pod-name>`          | Get detailed pod information |
 | `kubectl exec -it <pod-name> -- /bin/bash` | Access pod shell             |


### PR DESCRIPTION
…React components

Standardized environment variable naming by maintaining the VITE_ prefix in window.ENV object properties created by env.sh. This ensures consistent access patterns between runtime environment variables (window.ENV) and build-time variables (import.meta.env), preventing potential undefined variable issues in components.

Components like OrderPage.jsx, Weather.jsx, and PlantIdentifier.jsx now correctly access their respective API keys without fallback issues.